### PR TITLE
Save access token; add _api method; add profile method

### DIFF
--- a/t/30-profile.t
+++ b/t/30-profile.t
@@ -1,0 +1,35 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use Data::Dumper;
+use WebService::GarminConnect;
+
+# This test connects to Garmin Connect, so it will only run if
+# GARMIN_USERNAME and GARMIN_PASSWORD are set in the environment.
+#
+# If you run this test, this account must have at least 7 activities.
+#
+if (!defined $ENV{GARMIN_USERNAME} &&
+    !defined $ENV{GARMIN_PASSWORD} ) {
+  plan skip_all => 'set GARMIN_{USERNAME,PASSWORD} to run network tests';
+} else {
+  plan tests => 5;
+}
+
+my $gc = WebService::GarminConnect->new(
+  username => $ENV{GARMIN_USERNAME},
+  password => $ENV{GARMIN_PASSWORD},
+);
+isnt($gc, undef, "create instance");
+
+# Try to login. If this works, the 'is_logged_in' key should
+# be defined afterward.
+$gc->_login();
+ok(defined $gc->{is_logged_in}, "login succeeded");
+
+my $profile;
+ok($profile = $gc->profile, "profile obtained");
+ok(exists $profile->{userName}, "profile has a userName");
+is($profile->{userName}, $ENV{GARMIN_USERNAME}, "userName matches");


### PR DESCRIPTION
Hi,

Please consider these changes:
* After login, save access token in local .cache file
* Add a generic _api method
* Add a profile method (using _api method)
* Upon login, load access token and test validity with a call to the profile method
* Use _api method in activities
* Fix CSRF RE
* add t/30-profile.t test

Best!